### PR TITLE
Added support for parsing enums

### DIFF
--- a/examples/example.jai
+++ b/examples/example.jai
@@ -1,11 +1,26 @@
 
 // Data structures for typed parsing/printing
 LevelData :: struct {
+    kind : LevelKind;
+    flags : LevelFlags;
     secret: bool;
     player: Entity;
     player2: *Entity;
-	score: float;
+    score: float;
     entities: [..] Entity;
+    
+    
+    LevelKind :: enum {
+        EASY :: 0;
+        HARD :: 1;
+        LEGENDARY :: 2;
+    }
+
+    LevelFlags :: enum_flags {
+        FLAG_A :: 0x1;
+        FLAG_B :: 0x2;
+        FLAG_C :: 0x4;
+    }
 }
 
 Entity :: struct {
@@ -16,7 +31,7 @@ Entity :: struct {
 
 
 LEVEL_DATA_JSON := #string DONE
-{"secret": false,"score":5.5,"player": {"name": "Pat","x": 10,"y": 10},"player2": {"name": "Chris"},"entities": [{"name": "fdsa","x": 0,"y": 0},{"name": "fdsa","x": 0,"y": 0}]}
+{"kind" : ".HARD", "flags" : ".FLAG_A | .FLAG_C", "secret": false,"score":5.5,"player": {"name": "Pat","x": 10,"y": 10},"player2": {"name": "Chris"},"entities": [{"name": "fdsa","x": 0,"y": 0},{"name": "fdsa","x": 0,"y": 0}]}
 DONE;
 
 typed_parsing :: () {
@@ -29,13 +44,13 @@ typed_parsing :: () {
 }
 
 typed_printing :: () {
-	level := LevelData.{secret=true, score=500};
+    level := LevelData.{kind=.LEGENDARY, /*flags=LevelData.LevelFlags.FLAG_B|.FLAG_C,*/secret=true, score=500};
     level.player = .{name="Pat", x=4, y=4, dirty=true};
     array_add(*level.entities, .{name="Chris", x=6, y=6});
 
     json_string := json_write_string(level);
     print("Typed printing result:\n%\n\n", json_string);
-
+    
     // success := json_write_file("level.json", level, indent_char="");
     // assert(success);
 }
@@ -73,7 +88,7 @@ DONE
     // Print things out, for demonstration purposes
 
     traverse_node :: (node: JSON_Value, depth: int) {
-		INDENTATION :: 4;
+        INDENTATION :: 4;
         print("% ", node.type);
 
         if node.type == {
@@ -198,8 +213,8 @@ main :: () {
 
 		typed_parsing();
 		typed_printing();
-		generic_parsing();
-		generic_printing();
+		//generic_parsing();
+		//generic_printing();
 	}
 
     // Since the program ends here, this doesn't matter, but just setting an example.

--- a/examples/example.jai
+++ b/examples/example.jai
@@ -44,13 +44,13 @@ typed_parsing :: () {
 }
 
 typed_printing :: () {
-    level := LevelData.{kind=.LEGENDARY, /*flags=LevelData.LevelFlags.FLAG_B|.FLAG_C,*/secret=true, score=500};
+    level := LevelData.{kind=.LEGENDARY, flags=LevelData.LevelFlags.FLAG_B|.FLAG_C, secret=true, score=500};
     level.player = .{name="Pat", x=4, y=4, dirty=true};
     array_add(*level.entities, .{name="Chris", x=6, y=6});
 
     json_string := json_write_string(level);
     print("Typed printing result:\n%\n\n", json_string);
-    
+
     // success := json_write_file("level.json", level, indent_char="");
     // assert(success);
 }
@@ -88,7 +88,7 @@ DONE
     // Print things out, for demonstration purposes
 
     traverse_node :: (node: JSON_Value, depth: int) {
-        INDENTATION :: 4;
+		INDENTATION :: 4;
         print("% ", node.type);
 
         if node.type == {
@@ -213,8 +213,8 @@ main :: () {
 
 		typed_parsing();
 		typed_printing();
-		//generic_parsing();
-		//generic_printing();
+		generic_parsing();
+		generic_printing();
 	}
 
     // Since the program ends here, this doesn't matter, but just setting an example.

--- a/typed.jai
+++ b/typed.jai
@@ -124,7 +124,7 @@ json_write_native :: (builder: *String_Builder, data: *void, info: *Type_Info, i
 json_write_native_members :: (builder: *String_Builder, data: *void, members: [] Type_Info_Struct_Member, indent_char := "\t", ignore := ignore_by_note, level := 0, first: *bool) {
 	for * member: members {
 		if member.type.type == .TYPE	continue;
-		if ignore(member)	continue;
+		if ignore(member)				continue;
 		if (member.type.type == .STRUCT && member.flags & .USING) {
 			info := cast(*Type_Info_Struct) member.type;
 			json_write_native_members(builder, data + member.offset_in_bytes, info.members, indent_char, ignore, level, first);
@@ -390,7 +390,7 @@ parse_enum :: (str : string, slot: *u8, info_enum: *Type_Info_Enum) -> remainder
 		name := normalize_enum_value(value);
 		for info_enum.names {
 			if name == it {
-				int_value := info_enum.values[it_index];
+				int_value = info_enum.values[it_index];
 				success = write_integer(info_enum.internal_type, slot, int_value);
 				break;
 			}

--- a/typed.jai
+++ b/typed.jai
@@ -5,7 +5,7 @@
 //@Incomplete: The typed interface cannot yet parse into float members. (Because I haven’t needed it yet. 🙈) PRs welcome!
 json_parse_string :: (content: string, $T: Type, ignore_unknown := true) -> success: bool, T {
 	result: T;
-    if !content then return false, result;
+	if !content then return false, result;
 
 	info := type_info(T);
 	remainder, success := parse_value(content, cast(*u8)*result, info, ignore_unknown, "");
@@ -46,6 +46,14 @@ json_write_native :: (builder: *String_Builder, data: *void, info: *Type_Info, i
 			any_val.type = info;
 			any_val.value_pointer = data;
 			print_item_to_builder(builder, any_val);
+		case .ENUM;
+			any_val: Any;
+			any_val.type = info;
+			any_val.value_pointer = data;
+			
+			append(builder, #char "\"");
+			print_item_to_builder(builder, any_val);
+			append(builder, #char "\"");
 		case .STRING;
 			json_append_escaped(builder, <<(cast(*string) data));
 		case .ARRAY;
@@ -115,6 +123,7 @@ json_write_native :: (builder: *String_Builder, data: *void, info: *Type_Info, i
 
 json_write_native_members :: (builder: *String_Builder, data: *void, members: [] Type_Info_Struct_Member, indent_char := "\t", ignore := ignore_by_note, level := 0, first: *bool) {
 	for * member: members {
+		if member.type.type == .TYPE	continue;
 		if ignore(member)	continue;
 		if (member.type.type == .STRUCT && member.flags & .USING) {
 			info := cast(*Type_Info_Struct) member.type;
@@ -236,20 +245,27 @@ parse_value :: (to_parse: string, slot: *u8, info: *Type_Info, ignore_unknown: b
 				}
 			}
 		case #char "\"";
-			value: string;
-			value, remainder, success = parse_string(remainder);
-			stored := false;
-			defer if !stored	free(value);
-			if success && slot {
+			if info.type == .ENUM {
+				info_enum := cast(*Type_Info_Enum)info;
 				value_slot: *u8;
-				value_slot, success, is_generic = prepare_slot(.STRING, info, slot, to_parse);
-				if success {
-					if is_generic {
-						json_set(cast(*JSON_Value)value_slot, value);
-					} else {
-						<<cast(*string)value_slot = value;
+				value_slot, success, is_generic = prepare_slot(.INTEGER, info_enum.internal_type, slot, to_parse);
+				remainder, success = parse_enum(remainder, value_slot, info_enum);
+			} else {
+				value: string;
+				value, remainder, success = parse_string(remainder);
+				stored := false;
+				defer if !stored	free(value);
+				if success && slot {
+					value_slot: *u8;
+					value_slot, success, is_generic = prepare_slot(.STRING, info, slot, to_parse);
+					if success {
+						if is_generic {
+							json_set(cast(*JSON_Value)value_slot, value);
+						} else {
+							<<cast(*string)value_slot = value;
+						}
+						stored = true;
 					}
-					stored = true;
 				}
 			}
 		case #char "[";
@@ -320,6 +336,65 @@ parse_value :: (to_parse: string, slot: *u8, info: *Type_Info, ignore_unknown: b
 					}
 				}
 			}
+	}
+	
+	return remainder, success;
+}
+
+parse_enum :: (str : string, slot: *u8, info_enum: *Type_Info_Enum) -> remainder: string, success: bool {
+
+	value, remainder, success := parse_string(str);
+	defer free(value);
+	
+	// Try to parse as int
+	int_value: s64;
+	int_remainder: string;
+	int_value, success, int_remainder = to_integer(value);
+	
+	if success && int_remainder.count == 0 {
+		success = write_integer(info_enum.internal_type, slot, int_value);
+		return remainder, success;
+	}
+	
+	// Parse by members' names
+	normalize_enum_value :: inline (name : string) -> string #expand {
+		normalized := trim(name);
+		if starts_with(normalized, tprint("%.", info_enum.name))
+			normalized = slice(normalized, info_enum.name.count+1, normalized.count-info_enum.name.count-1);
+		if starts_with(normalized, ".")
+			normalized = slice(normalized, 1, normalized.count-1);
+		return normalized;
+	}
+	
+	if info_enum.enum_type_flags & .FLAGS {
+		parsed_count := 0;
+		values := split(value, "|");
+		
+		for v : values {
+			name := normalize_enum_value(v);
+			for info_enum.names {
+				if name == it {
+					parsed_count += 1;
+					int_value |= info_enum.values[it_index];
+					break;
+				}
+			}
+		}
+		if parsed_count == values.count {
+			success = write_integer(info_enum.internal_type, slot, int_value);
+		} else {
+			success = false;
+		}
+	} else {
+		success = false;
+		name := normalize_enum_value(value);
+		for info_enum.names {
+			if name == it {
+				int_value := info_enum.values[it_index];
+				success = write_integer(info_enum.internal_type, slot, int_value);
+				break;
+			}
+		}
 	}
 
 	return remainder, success;

--- a/typed.jai
+++ b/typed.jai
@@ -245,7 +245,7 @@ parse_value :: (to_parse: string, slot: *u8, info: *Type_Info, ignore_unknown: b
 				}
 			}
 		case #char "\"";
-			if info.type == .ENUM {
+			if slot && info && info.type == .ENUM {
 				info_enum := cast(*Type_Info_Enum)info;
 				value_slot: *u8;
 				value_slot, success, is_generic = prepare_slot(.INTEGER, info_enum.internal_type, slot, to_parse);


### PR DESCRIPTION
I added parsing for enums for "typed parser". Value of enum is always saved as string. Note that `print_item_to_builder` can save enum in three different ways: as `{Integer}`, as `{EnumType}.{EnumMember} | .{EnumMember}`, or `{EnumMember}`. And all of them are supported by parser in `normalize_enum_value`. 

Additionally, types which are declared inside the scope of parsed struct are now omitted (for example LevelData.LevelKind).

Example of usage has been added to example.jai.