### PR TITLE
Changed dependency name to match github and added missing method.

### DIFF
--- a/generic.jai
+++ b/generic.jai
@@ -382,4 +382,4 @@ parse_object :: (str: string) -> result: JSON_Object, remainder: string, success
 
 
 #import "Compiler";
-#import "unicode_utils";
+#import "jai-unicode";

--- a/module.jai
+++ b/module.jai
@@ -197,11 +197,39 @@ unescape :: (str: string) -> result: string, success: bool {
 	return result, true;
 }
 
+next_power_of_two :: inline (v: int) -> int {
+    ASM :: true;
+    #if ASM {
+        result: s64 = ---;
+        v -= 1;
+        // count leading zeros
+        #asm {
+            lzcnt result, v;
+        }
+        return 1 << (64 - result);
+    } else {
+        p := 1;
+        while p < v {
+            p += p;
+        }
+        return p;
+    }
+}
+
+maybe_grow :: inline (array: *Resizable_Array, elements: int) {
+    if array.count + elements >= array.allocated {
+        reserve := next_power_of_two(array.count + elements);
+        if reserve < 8  reserve = 8;
+
+        array_reserve(cast(*[..] u8) array, reserve);
+    }
+}
+
 #import "Basic";
 #import "File";
 #import "String";
 
 #import "Hash_Table";
-#import "unicode_utils";
+#import "jai-unicode";
 #import "IntroSort";
 


### PR DESCRIPTION
It seems like I'm missing a method called `maybe_grow` that takes an array and an element count.

I recreated it in module.jai, but I've never seen `Resizable_Array` before, so I'm not sure if casting to `*[..] u8` is correct.

Also, this library has a dependency on, `unicode_utils` the readme says, but the github name is `jai-unicode`. It would probably make more sense to change the import string, and change your folder name, rather than expecting that after cloning the dependency the user renames it.

---

Also @rluba, my version doesn't correctly handle this code.

```jai
main :: () {
    JsonType :: struct {
        // optional
        key1: *string;
        // required
        key2: float;
        // optional
        key3: *[..] float;
        // required
        key4: struct {
            key5: float;
            key6: *string;
        };
        // optional
        key7: *float;
        // optional
        key8: *float;
    }

    success, result := json_parse_string(JSON_STRING, JsonType);

    print("%\n%\n", success, result);
    print("key1 %\nkey3 %\nkey5.key6 %\nkey8 %\n", << result.key1, << result.key3, << result.key4.key6, 0);
}

JSON_STRING :: #string DONE
{
	"key2": 0.5,
	"key1": "hey",
	"key3": [0.4, 0.6, 0.8, 1.0],
	"key4": {
		"key5": 2.0,
		"key6": "lol"
	},
    "key8": 1.5
}
DONE

#import "Basic";
#import "jason";
```

I would expect that key8 becomes a pointer to 1.5, but it remains null. This seems like a bug.

I wasn't able to test this library without my `maybe_grow` changes, so I'm not sure if it's something that I caused in this PR, if I'm using the library incorrectly with respect to optional values (relying on pointers), or if it's legitimately a bug. Please let me know!