### PR TITLE
Use deinit instead of deprecated uninit

### DIFF
--- a/generic.jai
+++ b/generic.jai
@@ -46,7 +46,7 @@ json_free :: (using val: JSON_Value) {
 				free(it_index);
 				json_free(it);
 			}
-			uninit(object);
+			deinit(object);
 
 			free(object);
 	}


### PR DESCRIPTION
This PR remove the deprecated message if `uninit` was used instead of `deinit`.

Thanks for *jason* btw! :)