### PR TITLE
write_entire_file takes a pointer to a String_Builder.

### DIFF
--- a/module.jai
+++ b/module.jai
@@ -18,7 +18,7 @@ json_write_file :: (filename: string, value: $T, indent_char := "\t", ignore := 
 	builder: String_Builder;
 	defer free_buffers(*builder);
 	json_append_value(*builder, value, indent_char, ignore, rename);
-	return write_entire_file(filename, builder);
+	return write_entire_file(filename, *builder);
 }
 
 json_append_value :: (builder: *String_Builder, val: $T, indent_char := "\t", ignore := ignore_by_note, rename := rename_by_note) {


### PR DESCRIPTION
Fix compile error in the following: `json_write_file( "foo", SomeStruct.{ ... } );`

The expansion of json_write_file leads to invalid invocation of write_entire_file, which requires a String_Builder pointer.