### PR TITLE
add support for fixed-size arrays

### DIFF
--- a/typed.jai
+++ b/typed.jai
@@ -425,8 +425,6 @@ parse_array :: (str: string, slot: *u8, info: *Type_Info_Array, ignore_unknown: 
 	element_size: int;
 	stride: int;
 	if slot {
-		assert(info.array_count == -1, "Fixed array are not implemented yet");
-
 		element_size = info.element_type.runtime_size;
 		assert(element_size != -1, "Unknown element size");
 		stride = get_array_stride(element_size);
@@ -471,7 +469,15 @@ parse_array :: (str: string, slot: *u8, info: *Type_Info_Array, ignore_unknown: 
 			remainder = advance(remainder);
 			remainder = trim_left(remainder, WHITESPACE_CHARS);
 		}
-		if info.array_type == .VIEW {
+
+		if info.array_count != -1 { // fixed-size array
+			for i : 0..info.array_count-1 {
+				element := cast(*u8)(array.data + i * stride);
+				for byte : 0..element_size-1 {
+					memset(slot + (i * element_size) + byte, (element + byte).*, 1);
+				}
+			}
+		} else if info.array_type == .VIEW {
 			view := (cast(*Array_View_64) slot);
 			view.count = array.count;
 			view.data = array.data;


### PR DESCRIPTION
This PR adds support for fixed-size arrays, which is done by copying the bytes according to the element size into the memory offset for each element in the slot, according to the count of the array.

TBH, I don't have a super strong background in working with memory like this, so please let me know if I'm doing something stupid here. But it seems to work correctly!